### PR TITLE
Install base-devel and sudo before excuting the makepkg

### DIFF
--- a/build-pkgbuild
+++ b/build-pkgbuild
@@ -10,7 +10,7 @@ fi
 cd /build
 chown -R makepkg:users /build
 
-pacman -Sy
+pacman -Sy && pacman -S base-devel sudo --noconfirm
 sudo -u makepkg makepkg --noconfirm -sf
 
 mv $package*.pkg.tar.xz /pkg


### PR DESCRIPTION
Just found out while testing building arch pkgbuilds in Fedora.