### PR TITLE
Add script to build repo packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM archlinux/base:latest
 
-RUN pacman -Syu --noconfirm --needed base base-devel git && \
+RUN pacman -Syu --noconfirm --needed base base-devel git asp && \
     useradd -d /home/makepkg makepkg && \
     mkdir -p /home/makepkg/.config/pacman && \
     echo 'MAKEFLAGS="-j$(nproc)"' > /home/makepkg/.config/pacman/makepkg.conf && \
@@ -11,4 +11,5 @@ RUN pacman -Syu --noconfirm --needed base base-devel git && \
 VOLUME /pkg /build
 
 COPY sudoers /etc/sudoers
-COPY build-aur build-pkgbuild /
+COPY build-aur build-pkgbuild build-repo /
+

--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ $ docker pull maximbaz/arch-build-aur
 $ docker run --rm -v $(pwd):/pkg maximbaz/arch-build-aur /bin/bash -c '/build-aur <package>'
 ```
 
+### Build repo packages
+
+The following command will download repo package and build it:
+
+```
+$ docker pull maximbaz/arch-build-aur
+$ docker run --rm -v $(pwd):/pkg maximbaz/arch-build-aur /bin/bash -c '/build-repo <package>'
+```
+
 ### Build PKGBUILD
 
 The following command will build local PKGBUILD file (must reside in a folder mounted to /build):

--- a/build-repo
+++ b/build-repo
@@ -11,6 +11,15 @@ package=$1
 
 chown -R makepkg:users /build
 
-cd /tmp && sudo -u makepkg asp checkout $package && mv $package/trunk/* /build && cd /
+cd /tmp
+sudo -u makepkg asp checkout "$package"
+mv "$package"/repos/{core,extra,community}-{any,x86_64}/* /build 2>/dev/null || true
+cd /
 
-/build-pkgbuild
+if [ -f /build/PKGBUILD ]
+then
+	/build-pkgbuild
+else
+	echo "Unsupported package: error in choosing repository or architecture."
+	exit 1
+fi

--- a/build-repo
+++ b/build-repo
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ "$#" -ne 1 ]; then
+  echo -e "Please provide repo package name to build\nUsage: docker run --rm -v \$(pwd):/pkg maximbaz/arch-build-aur /bin/bash -c '/build-repo <package-name>'"
+  exit 1
+fi
+
+package=$1
+
+chown -R makepkg:users /build
+
+cd /tmp && sudo -u makepkg asp checkout $package && mv $package/trunk/* /build && cd /
+
+/build-pkgbuild


### PR DESCRIPTION
I've written an additional script to build repo packages, and added asp to the image in order to pull the build files. As written it will always build the `trunk` package, but that's the one you get with e.g. yay, so I figured it's an acceptable compromise. Feel free to reject if I'm the only weirdo who semi-regularly rebuilds repo packages without changing them :) 