### PR TITLE
Run full system upgrade before building

### DIFF
--- a/build-pkgbuild
+++ b/build-pkgbuild
@@ -10,6 +10,7 @@ fi
 cd /build
 chown -R makepkg:users /build
 
+pacman -Syu --noconfirm
 sudo -u makepkg makepkg --noconfirm -sf
 
 mv $package*.pkg.tar.xz /pkg


### PR DESCRIPTION
Arch being Arch, even rebuilding the image daily isn't always enough - my first attempt at using this image failed because of a dependency updated in the meantime. I've added a full system upgrade to be performed before the build step. Again, feel free to reject if this might be an issue for any reason I've overlooked.