### PR TITLE
use PKGDEST to specify package destination

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM archlinux/base:latest
 RUN pacman -Syu --noconfirm --needed base base-devel git asp && \
     useradd -d /home/makepkg makepkg && \
     mkdir -p /home/makepkg/.config/pacman && \
-    echo 'MAKEFLAGS="-j$(nproc)"' > /home/makepkg/.config/pacman/makepkg.conf && \
+    echo 'MAKEFLAGS="-j$(nproc)"' >> /home/makepkg/.config/pacman/makepkg.conf && \
+    echo 'PKGDEST="/home/makepkg/out"' >> /home/makepkg/.config/pacman/makepkg.conf && \
+    mkdir '/home/makepkg/out' && \
     mkdir -p /home/makepkg/.gnupg && \
     echo 'keyserver-options auto-key-retrieve' > /home/makepkg/.gnupg/gpg.conf && \
     chown -R makepkg:users /home/makepkg

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,9 @@ FROM archlinux/base:latest
 
 RUN pacman -Syu --noconfirm --needed base base-devel git asp && \
     useradd -d /home/makepkg makepkg && \
-    mkdir -p /home/makepkg/.config/pacman && \
+    mkdir -p /home/makepkg/{.config/pacman,.gnupg,out} && \
     echo 'MAKEFLAGS="-j$(nproc)"' >> /home/makepkg/.config/pacman/makepkg.conf && \
     echo 'PKGDEST="/home/makepkg/out"' >> /home/makepkg/.config/pacman/makepkg.conf && \
-    mkdir '/home/makepkg/out' && \
-    mkdir -p /home/makepkg/.gnupg && \
     echo 'keyserver-options auto-key-retrieve' > /home/makepkg/.gnupg/gpg.conf && \
     chown -R makepkg:users /home/makepkg
 
@@ -14,4 +12,3 @@ VOLUME /pkg /build
 
 COPY sudoers /etc/sudoers
 COPY build-aur build-pkgbuild build-repo /
-

--- a/build-pkgbuild
+++ b/build-pkgbuild
@@ -13,4 +13,4 @@ chown -R makepkg:users /build
 pacman -Syu --noconfirm
 sudo -u makepkg makepkg --noconfirm -sf
 
-mv $package*.pkg.tar.* /pkg
+mv /home/makepkg/out/* /pkg


### PR DESCRIPTION
This implements my suggestion from https://github.com/maximbaz/docker-arch-build-aur/issues/7#issuecomment-695945520.

There is a new directory named `out` in the makepkg user's home directory. This directory is used as `PKGDEST`, so that the built package is placed there. Since the directory is otherwise empty, `mv /home/makepkg/out/* /pkg` moves the package no matter the file extension.